### PR TITLE
Fixed comment input iPhone 6S plus issue

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -814,7 +814,9 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
     // If the input is in the bottom, the only position accepted is when the keyboard full appear
     CGFloat keyboardHeight = keyboardFrame.size.height;
-    if ((heightFromBottom != keyboardHeight + 1 && heightFromBottom != keyboardHeight) && self.toolbarBottomLayoutGuide.constant <= 1) {
+    if ((heightFromBottom > keyboardHeight + 1 || heightFromBottom < keyboardHeight) 
+        && self.toolbarBottomLayoutGuide.constant <= 1) {
+        
         return;
     }
     

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -815,7 +815,6 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     // If the input is in the bottom, the only position accepted is when the keyboard full appear
     CGFloat keyboardHeight = keyboardFrame.size.height;
     if ((heightFromBottom > keyboardHeight + 1 || heightFromBottom < keyboardHeight)  && self.toolbarBottomLayoutGuide.constant <= 1) {
-        
         return;
     }
     

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -814,8 +814,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
     // If the input is in the bottom, the only position accepted is when the keyboard full appear
     CGFloat keyboardHeight = keyboardFrame.size.height;
-    if ((heightFromBottom > keyboardHeight + 1 || heightFromBottom < keyboardHeight) 
-        && self.toolbarBottomLayoutGuide.constant <= 1) {
+    if ((heightFromBottom > keyboardHeight + 1 || heightFromBottom < keyboardHeight)  && self.toolbarBottomLayoutGuide.constant <= 1) {
         
         return;
     }


### PR DESCRIPTION
We have an issue with the iPhone 6S plus because the `heightFromBottom` is not a rounded float (271.66667), then we need to compare with > and < instead of !=
