### PR TITLE
Fix toolbar position if navigation bar is not translucent

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -837,7 +837,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
         return;
     }
 
-    CGFloat heightFromBottom = CGRectGetMaxY(keyboardController.contextView.frame) - CGRectGetMinY(keyboardFrame);
+    CGFloat heightFromBottom = CGRectGetMaxY(keyboardController.contextView.frame) - CGRectGetMinY(keyboardFrame) -
+        keyboardController.contextView.frame.origin.y;
 
     // If the input is in the bottom, the only position accepted is when the keyboard full appear
     CGFloat keyboardHeight = keyboardFrame.size.height;

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -837,8 +837,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
         return;
     }
 
-    CGFloat heightFromBottom = CGRectGetMaxY(keyboardController.contextView.frame) - CGRectGetMinY(keyboardFrame) -
-        keyboardController.contextView.frame.origin.y;
+    CGFloat heightFromBottom = CGRectGetHeight(keyboardController.contextView.frame) - CGRectGetMinY(keyboardFrame);
 
     // If the input is in the bottom, the only position accepted is when the keyboard full appear
     CGFloat keyboardHeight = keyboardFrame.size.height;


### PR DESCRIPTION
This fix the issue where the toolbar position was not properly updated if the navigation bar has isTranslucent in false, and the reason was that the `keyboardController.contextView.frame.origin.y` was not 0 in that case